### PR TITLE
Harden DEPLOY_HOST parsing in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,24 @@ jobs:
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
+          # Secrets pasted through a browser routinely pick up trailing
+          # newlines, spaces or quotes; ssh rejects those with the unhelpful
+          # "hostname contains invalid characters".
+          host="$(printf '%s' "$DEPLOY_HOST" | tr -d '[:space:]' | tr -d '"'"'"'')"
+          host="${host#*://}"          # tolerate someone pasting a URL
+          host="${host%%/*}"
+
+          if [ -z "$host" ]; then
+            echo "::error::DEPLOY_HOST secret is empty" && exit 1
+          fi
+          case "$host" in
+            *[!a-zA-Z0-9.:-]*)
+              echo "::error::DEPLOY_HOST still has invalid characters after cleanup (length ${#host})"
+              exit 1 ;;
+          esac
+
           ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes \
-              "zuallite@${DEPLOY_HOST}" 'bash -s' < deploy/remote-deploy.sh
+              "zuallite@${host}" 'bash -s' < deploy/remote-deploy.sh
 
       - name: Verify public endpoint
         env:


### PR DESCRIPTION
`DEPLOY_HOST` pasted through the browser carried stray characters, so ssh failed with `hostname contains invalid characters` (run 30757434421).

Strips whitespace and quotes, tolerates a pasted `https://…/` URL, and fails with an actionable message instead of ssh's cryptic one.

Also set on the repo alongside this: `SITE_URL` variable was missing entirely, so the final verify step would have curled an empty URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)